### PR TITLE
Fix issue when importing from module_logging

### DIFF
--- a/objectdetection_fd_rknn.py
+++ b/objectdetection_fd_rknn.py
@@ -23,7 +23,7 @@ from threading import Lock
 from numpy import array
 from PIL import UnidentifiedImageError
 
-from module_logging import LogMethod
+from codeproject_ai_sdk.module_logging import LogMethod
 from options import Options
 
 # import fastdeploy as fd # rknn


### PR DESCRIPTION
The SDK is installed as a package in the python virtual environment and must include the package name to find the module.

See issue https://github.com/codeproject/CodeProject.AI-Server/issues/131 for more details.